### PR TITLE
Fix: createdAgo accurate on any timezone

### DIFF
--- a/migrate/001_setup.up.sql
+++ b/migrate/001_setup.up.sql
@@ -30,7 +30,7 @@ create table posts (
   slug text not null unique,
   body text not null,
   status post_status not null default 'draft',
-  created_at timestamp not null default now(),
-  updated_at timestamp not null default now()
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now()
 );
 create trigger updated_at before update on posts for each row execute procedure set_updated_at();


### PR DESCRIPTION
add in timezone data to the posts table 
for accurate result for the `createdAgo`(`timeago`) prop for the views