### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,19 @@ Since this repository is acting as a "canary" for future features, **[please sha
 
 ## Install
 
+**Prerequisite**
+
+1. [`direnv`](https://direnv.net/docs/installation.html)
+2. go >= 1.18
+3. Install the following tools to your go path
+
+```sh
+$ go install github.com/matthewmueller/migrate/cmd/migrate
+$ go install github.com/matthewmueller/pogo/cmd/pogo
+```
+
+**Setup**
+
 ```sh
 # Install go dependencies
 go mod tidy


### PR DESCRIPTION
Optional update for the documentation for systems where the `tools.go` doesn't link the binaries as expected. 

While the installation of the mentioned tools do go through, the binaries aren't linked as expected (at least on a M1 Air 2020), so proposing this addition  for cases where someone might need to install them manually.